### PR TITLE
Fix IPv6 pools

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -187,6 +187,10 @@ class Neutron():
             size = 0
             for subnet in n['subnets']:
                 for pool in self.subnet_map[subnet]['pool']:
+                    if ':' in pool['start']:
+                        # Skip IPv6 address pools; they are big enough to
+                        # drown the IPv4 numbers we might care about.
+                        continue
                     size += len(list(iter_iprange(pool['start'], pool['end'])))
             l = [config['cloud'], self.network_map[n['id']]]
             net_size.labels(*l).set(size)


### PR DESCRIPTION
The current method used by prometheus-openstack-exporter to find the
number of IP addresses in a pool is to have iter_iprange enumerate the
addresses in the pool. This works for small pools which are quite
typical for IPv4 address pools. With IPv6 pools, however, typical pool
sizes are large enough that prometheus-openstack-exporter will try to
eat up all of the computer's RAM which, depending on the host system's
configuration, can result in the host becoming completely unresponsive.

The value of showing the user the number of addresses in such a large
IPv6 pool is dubious to begin with, and adding it to the number of IPv4
addresses just ensures that the resulting number is virtually
meaningless.

Therefore, this patch simply skips IPv6 addresses when counting
IP addresses.