### PR TITLE
Use IPRange size attribute instead

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -40,7 +40,7 @@ from BaseHTTPServer import BaseHTTPRequestHandler
 from BaseHTTPServer import HTTPServer
 from SocketServer import ForkingMixIn
 from prometheus_client import CollectorRegistry, generate_latest, Gauge, CONTENT_TYPE_LATEST
-from netaddr import IPRange 
+from netaddr import IPRange
 
 
 def get_creds_dict(*names):
@@ -256,10 +256,6 @@ class Neutron():
                     if ':' in pool['start']:
                         # Skip IPv6 address pools; they are big enough to
                         # drown the IPv4 numbers we might care about.
-                        # Alternatively, we could add IPv4/IPv6 metric labels
-                        # and do something like this:
-                        # int(IPAddress(pool['end'])) -
-                        #     int(IPAddress(pool['start']))
                         continue
                     size += IPRange(pool['start'], pool['end']).size
             l = [config['cloud'], self.network_map[n['id']]]

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -271,6 +271,7 @@ class Nova():
                 schedulable_instances_capacity.labels(*l).set(self._get_schedulable_instances_capacity(h))
 
     def gen_instance_stats(self):
+        missing_flavors = False
         instances = Gauge('nova_instances',
                           'Nova instances metrics',
                           ['cloud', 'tenant', 'instance_state'], registry=self.registry)
@@ -288,12 +289,27 @@ class Nova():
                 tenant = self.tenant_map[i['tenant_id']]
             else:
                 tenant = 'orphaned'
-            flavor = self.flavor_map[i['flavor']['id']]
-
             instances.labels(config['cloud'], tenant, i['status']).inc()
-            res_ram.labels(config['cloud'], tenant).inc(flavor['ram'])
-            res_vcpus.labels(config['cloud'], tenant).inc(flavor['vcpus'])
-            res_disk.labels(config['cloud'], tenant).inc(flavor['disk'])
+
+            if i['flavor']['id'] in self.flavor_map:
+                flavor = self.flavor_map[i['flavor']['id']]
+                res_ram.labels(config['cloud'], tenant).inc(flavor['ram'])
+                res_vcpus.labels(config['cloud'], tenant).inc(flavor['vcpus'])
+                res_disk.labels(config['cloud'], tenant).inc(flavor['disk'])
+            else:
+                missing_flavors = True
+
+        # If flavors were deleted we can't reliably find out resouerce use
+        if missing_flavors:
+            self.registry.unregister(res_ram)
+            self.registry.unregister(res_vcpus)
+            self.registry.unregister(res_disk)
+            res_ram = Gauge('nova_resources_ram_mbs', 'Nova RAM usage metric unavailable, missing flavors',
+                            [], registry=self.registry)
+            res_vcpus = Gauge('nova_resources_vcpus', 'Nova vCPU usage metric unavailable, missing flavors',
+                              [], registry=self.registry)
+            res_disk = Gauge('nova_resources_disk_gbs', 'Nova disk usage metric unavailable, missing flavors',
+                             [], registry=self.registry)
 
     def gen_overcommit_stats(self):
         labels = ['cloud', 'resource']

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -40,7 +40,7 @@ from BaseHTTPServer import BaseHTTPRequestHandler
 from BaseHTTPServer import HTTPServer
 from SocketServer import ForkingMixIn
 from prometheus_client import CollectorRegistry, generate_latest, Gauge, CONTENT_TYPE_LATEST
-from netaddr import iter_iprange
+from netaddr import IPRange 
 
 
 class DataGatherer(Thread):
@@ -187,7 +187,7 @@ class Neutron():
             size = 0
             for subnet in n['subnets']:
                 for pool in self.subnet_map[subnet]['pool']:
-                    size += len(list(iter_iprange(pool['start'], pool['end'])))
+                    size += IPRange(pool['start'], pool['end']).size 
             l = [config['cloud'], self.network_map[n['id']]]
             net_size.labels(*l).set(size)
 


### PR DESCRIPTION
casting to list then iterating to get size of subnet is inefficient and falls over on larger clouds, use IPRange size attribute instead