### PR TITLE
Fix regression that made all environment variables compulsory

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -44,8 +44,9 @@ from netaddr import iter_iprange
 
 
 def get_creds_dict(*names):
-    """Get dictionary with cred envvars, error if not set"""
-    return {name: env['OS_%s' % name.upper()] for name in names}
+    """Get dictionary with cred envvars"""
+    return {name: env['OS_%s' % name.upper()]
+        for name in names if 'OS_%s' % name.upper() in env}
 
 def get_creds_list(*names):
     """Get list with cred envvars, error if not set"""


### PR DESCRIPTION
The function, get_creds_list, has recently been fixed to ensure that
it does not return an array with elements in incorrect positions if
not all expected OS_* environment variables are present.

get_creds_dict received the same treatment. This was not necessary
because that function returns a dictionary: elements may be missing, but
one will never confused for another (because both key and value will be
missing). However, the change in get_creds_dict caused a problem: every
single argument must have the corresponding environment variable set or
the script will abort, forcing the user to provide redundant arguments
(e.g., PROJECT_DOMAIN_ID when PROJECT_DOMAIN_NAME is already present).

The patch reverts get_creds_dicts back to the correct version.