### PR TITLE
New format in tenant_id returned by router-list on ocata

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import argparse
 import yaml
 import json
+import ast
 from os import environ as env
 from os import rename, path
 import traceback
@@ -243,6 +244,8 @@ class Neutron():
         ips = {}
         for r in self.routers:
             if self._get_router_ip(r['id']):
+                if r['tenant_id'].startswith('<Tenant {'):
+                    r['tenant_id'] = ast.literal_eval(r['tenant_id'][8:-1])['id']
                 try:
                     tenant = self.tenant_map[r['tenant_id']]
                 except KeyError:


### PR DESCRIPTION
When run on an ocata openstack cloud, prometheus-openstack-exporter fails with:

```
  File "/snap/prometheus-openstack-exporter/10/bin/prometheus-openstack-exporter", line 437, in do_GET
    swift.get_stats() + \
  File "/snap/prometheus-openstack-exporter/10/bin/prometheus-openstack-exporter", line 197, in get_stats
    ips.update(self.get_router_ips())
  File "/snap/prometheus-openstack-exporter/10/bin/prometheus-openstack-exporter", line 172, in get_router_ips
    tenant = self.tenant_map[r['tenant_id']]
KeyError: u"<Tenant {u'enabled': True, u'description': u'my_project', u'name': u'my_project', u'id': u'<the real tenant id>'}>"
```

`neutron router-list --debug` output differs in the same way:

- Mitaka:

`RESP BODY: {"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id": [...] , "tenant_id": "<the real tenant id>", [...]}
`

- Ocata:

`RESP BODY: {"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id": [...] , "tenant_id": "<Tenant {u'enabled': True, u'description': u'my_project', u'name': u'my_project', u'id': u'<the real tenant id>'}>", "created_at": [...]}
`

This commit makes it work with both versions.

NB: the above error is with p-o-e snap v0.0.3. I can see in more recent commits that the error would now be caught intead of crashing, but we wouldn't get any data for routers.