### PR TITLE
snap: add libdb5.3 as stage-package

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,6 +16,8 @@ parts:
     plugin: python
     python-version: python2
     source: .
+    stage-packages:
+      - libdb5.3
   example-config:
     plugin: dump
     source: .


### PR DESCRIPTION
As suggested by the following snapcraft message:
```
[...]
Priming prometheus-openstack-exporter 
Files from the build host were migrated into the snap to satisfy dependencies that would otherwise not be met. This feature will be removed in a future release. If these libraries are needed in the final snap, ensure that the following are either satisfied by a stage-packages entry or through a part:
snap/core/current/usr/lib/x86_64-linux-gnu/libdb-5.3.so
Snapping 'prometheus-openstack-exporter' |                                               
Snapped prometheus-openstack-exporter_0.0.7_amd64.snap
```