### PR TITLE
logging: fallback to StreamHandler only if SyslogHandler is not avaliable

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -654,6 +654,7 @@ if __name__ == '__main__':
     for logsock in ('/dev/log', '/var/run/syslog'):
         if path.exists(logsock):
             log.addHandler(logging.handlers.SysLogHandler(address=logsock))
+            break
     else:
         log.addHandler(logging.StreamHandler())
     config = yaml.safe_load(args.config_file.read())


### PR DESCRIPTION
Previous change d2431182dabd290971c786a790c275853ddf95bc missed a break in
loop. Without this change, log goes both syslog and stderr.