### PR TITLE
Add per instance info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ prime
 *.snap
 snap
 stage
+.cache
+.vscode
+*.egg-info

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -468,20 +468,19 @@ class Nova():
                     i['id'], i['name'], i['tenant_id'], i['user_id'],
                     i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone'])
-                    .set(1)
+                    i['OS-EXT-AZ:availability_zone']).set(1)
             instance_info_launch.labels(config['cloud'],
                     i['id'], i['name'], i['tenant_id'], i['user_id'],
                     i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone'])
-                    .set(dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
+                    i['OS-EXT-AZ:availability_zone']).set(
+                        dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
             instance_info_create.labels(config['cloud'],
                     i['id'], i['name'], i['tenant_id'], i['user_id']
                     , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone'])
-                    .set(dp.parse(i['created']).strftime('%s'))
+                    i['OS-EXT-AZ:availability_zone']).set(
+                        dp.parse(i['created']).strftime('%s'))
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -418,6 +418,12 @@ class Nova():
         instances = Gauge('nova_instances',
                           'Nova instances metrics',
                           ['cloud', 'tenant', 'instance_state'], registry=self.registry)
+        instance_info=Gauge('nova_instance_info',
+                            'Information about specific instances',
+                            ['cloud','id', 'name', 'tenant_id',
+                            'user_id', 'vm_state', 'power_state',
+                            'hypervisor_hostname', 'flavor', 'az']
+                            , registry=self.registry)
         res_ram = Gauge('nova_resources_ram_mbs',
                         'Nova RAM usage metric',
                         ['cloud', 'tenant'], registry=self.registry)
@@ -434,13 +440,23 @@ class Nova():
                 tenant = 'orphaned'
             instances.labels(config['cloud'], tenant, i['status']).inc()
 
-            if i['flavor']['id'] in self.flavor_map:
-                flavor = self.flavor_map[i['flavor']['id']]
+            f_id=i['flavor']['id']
+            flavorname=f_id
+            if f_id in self.flavor_map:
+                flavor = self.flavor_map[f_id]
                 res_ram.labels(config['cloud'], tenant).inc(flavor['ram'])
                 res_vcpus.labels(config['cloud'], tenant).inc(flavor['vcpus'])
                 res_disk.labels(config['cloud'], tenant).inc(flavor['disk'])
+                flavorname=flavor['name']
             else:
                 missing_flavors = True
+
+            instance_info.labels(config['cloud'],
+                    i['id'], i['name'], i['tenant_id'], i['user_id'],
+                    i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
+                    i['OS-EXT-SRV-ATTR:host'], flavorname,
+                    i['OS-EXT-AZ:availability_zone'])
+                    .set(1)
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -31,6 +31,7 @@ import urlparse
 from threading import Thread
 import pickle
 import requests
+import dateutil.parser as dp
 from time import sleep, time
 from neutronclient.v2_0 import client as neutron_client
 # from novaclient.v1_1 import client as nova_client
@@ -424,6 +425,18 @@ class Nova():
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
+        instance_info_launch=Gauge('nova_instance_launch_s',
+                            'Information about specific instances',
+                            ['cloud','id', 'name', 'tenant_id',
+                            'user_id', 'vm_state', 'power_state',
+                            'hypervisor_hostname', 'flavor', 'az']
+                            , registry=self.registry)
+        instance_info_create=Gauge('nova_instance_created_s',
+                            'Information about specific instances',
+                            ['cloud','id', 'name', 'tenant_id',
+                            'user_id', 'vm_state', 'power_state',
+                            'hypervisor_hostname', 'flavor', 'az']
+                            , registry=self.registry)
         res_ram = Gauge('nova_resources_ram_mbs',
                         'Nova RAM usage metric',
                         ['cloud', 'tenant'], registry=self.registry)
@@ -457,6 +470,18 @@ class Nova():
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
                     i['OS-EXT-AZ:availability_zone'])
                     .set(1)
+            instance_info_launch.labels(config['cloud'],
+                    i['id'], i['name'], i['tenant_id'], i['user_id'],
+                    i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
+                    i['OS-EXT-SRV-ATTR:host'], flavorname,
+                    i['OS-EXT-AZ:availability_zone'])
+                    .set(dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
+            instance_info_create.labels(config['cloud'],
+                    i['id'], i['name'], i['tenant_id'], i['user_id']
+                    , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
+                    i['OS-EXT-SRV-ATTR:host'], flavorname,
+                    i['OS-EXT-AZ:availability_zone'])
+                    .set(dp.parse(i['created']).strftime('%s'))
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -338,7 +338,7 @@ class Nova():
             self.prodstack = pickle.load(f)[0]
         self.hypervisors = self.prodstack['hypervisors']
         self.tenant_map = {t['id']: t['name'] for t in self.prodstack['tenants']}
-        self.flavor_map = {f['id']: {'ram': f['ram'], 'disk': f['disk'], 'vcpus': f['vcpus']}
+        self.flavor_map = {f['id']: {fk:f[fk] for fk in f.keys() }
                            for f in self.prodstack['flavors']}
         self.aggregate_map = {}
         self.services_map = {}

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -140,6 +140,7 @@ class DataGatherer(Thread):
         log.debug("Starting data gather thread")
         prodstack = {}
         while True:
+            log.debug('gathering run starts')
             start_time = time()
             try:
                 keystone, nova, neutron, cinder = get_clients()
@@ -195,6 +196,7 @@ class DataGatherer(Thread):
                 rename(self.cache_file + '.new', self.cache_file)
                 log.debug("Done dumping stats to {}".format(self.cache_file))
             self.duration = time() - start_time
+            log.debug('gathering run finished, sleeping now')
             sleep(self.refresh_interval)
 
     def get_stats(self):

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -647,7 +647,7 @@ if __name__ == '__main__':
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('config_file', nargs='?',
                         help='Configuration file path',
-                        default='/etc/prometheus/prometheus-openstack-exporter.yaml',
+                        default='./prometheus-openstack-exporter.yaml',
                         type=argparse.FileType('r'))
     args = parser.parse_args()
     log.setLevel(logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
                       "python-novaclient==6.0.0",
                       "python-neutronclient<=6.1.0",
                       "python-cinderclient",
+                      "python-dateutil",
                       "netaddr"],
     long_description=read('README.md'),
     classifiers=[


### PR DESCRIPTION
This branch creates per-vm statistics, that can be used afterwards in prometheus to enrich the metrics with specific VM-Info

It also works around a possible headache with argparse, because the default for the config-file is set to /etc/* and argparse crashes hard (even when a different configfile is specified) when the default-file is not there. It makes IMHO totally sense to have at least a default, pointing to a location owned by root, because the exporter itself doesn't need root privileges on the system its running on. 
