### PR TITLE
add support for exporting per-account swift usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,20 @@ Swift stats are included mainly because they are trivial to retrieve. If and whe
 
 We are aware that Prometheus best practise is to avoid caching. Unfortunately queries we need to run are very heavy and in bigger clouds can take minutes to execute. This is problematic not only because of delays but also because multiple servers scraping the exporter could have negative impact on the cloud performance
 
+## How are Swift account metrics obtained?
+
+Fairly simply!  Given a copy of the Swift rings (in fact, we just need
+account.ring.gz) we can load this up and then ask it where particular
+accounts are located in the cluster.  We assume that Swift is
+replicating properly, pick a node at random, and ask it for the
+account's statistics with an HTTP HEAD request, which it returns.
+
+## How hard would it be to export Swift usage by container?
+
+Sending a GET request to the account URL yields a list of containers
+(probably paginated, so watch out for that!).  In order to write a
+container-exporter, one could add some code to fetch a list of
+containers from the account server, load up the container ring, and
+then use container_ring.get_nodes(account, container) and HTTP HEAD on
+one of the resulting nodes to get a containers' statistics, although
+without some caching cleverness this will scale poorly.

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -689,6 +689,26 @@ class ForkingHTTPServer(ForkingMixIn, HTTPServer):
     pass
 
 
+# This could perhaps be cleverer, but surely not simpler.
+COLLECTORS = {
+    'cinder': Cinder,
+    'neutron': Neutron,
+    'nova': Nova,
+    'swift': Swift,
+    'swift-account-usage': SwiftAccountUsage,
+    }
+
+DATA_GATHERER_USERS = [
+    'cinder',
+    'neutron',
+    'nova',
+    ]
+
+
+def data_gatherer_needed(config):
+    return set(config['enabled_collectors']).intersection(DATA_GATHERER_USERS)
+
+
 class OpenstackExporterHandler(BaseHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
@@ -697,18 +717,14 @@ class OpenstackExporterHandler(BaseHTTPRequestHandler):
         url = urlparse.urlparse(self.path)
         if url.path == '/metrics':
             try:
-                neutron = Neutron()
-                nova = Nova()
-                cinder = Cinder()
-                swift = Swift()
-                swift_account_usage = SwiftAccountUsage()
+                collectors = [COLLECTORS[collector]() for collector in config['enabled_collectors']]
                 log.debug("Collecting stats..")
-                output = neutron.get_stats() + \
-                    nova.get_stats() + \
-                    cinder.get_stats() + \
-                    swift.get_stats() + \
-                    swift_account_usage.get_stats() + \
-                    data_gatherer.get_stats()
+                output = ''
+                for collector in collectors:
+                    output += collector.get_stats()
+                if data_gatherer:
+                    output += data_gatherer.get_stats()
+
                 self.send_response(200)
                 self.send_header('Content-Type', CONTENT_TYPE_LATEST)
                 self.end_headers()
@@ -752,7 +768,9 @@ if __name__ == '__main__':
     else:
         log.addHandler(logging.StreamHandler())
     config = yaml.safe_load(args.config_file.read())
-    data_gatherer = DataGatherer()
-    data_gatherer.start()
+    data_gatherer = None
+    if data_gatherer_needed(config):
+        data_gatherer = DataGatherer()
+        data_gatherer.start()
     server = ForkingHTTPServer(('', config.get('listen_port')), handler)
     server.serve_forever()

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -47,7 +47,7 @@ from netaddr import IPRange
 import random
 import swift.common.utils
 
-from swift.common.ring import ring
+from swift.common.ring.ring import Ring
 
 import logging
 import logging.handlers
@@ -649,7 +649,7 @@ class SwiftAccountUsage():
 
     def _get_account_ring(self):
         """Read the account ring from the configured location, and return it."""
-        return ring.Ring(
+        return Ring(
             serialized_path=self.ring_path,
             ring_name='account',
             )

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -634,7 +634,12 @@ class SwiftAccountUsage():
         self.reseller_prefix = config['reseller_prefix']
         self.ring_path = config['ring_path']
 
-        self.account_ring = self._get_account_ring()
+        try:
+            self.account_ring = self._get_account_ring()
+        except SystemExit:
+            # Most likely raised by swift.common.utils.validate_configuration().
+            raise Exception(
+                "Is swift.conf readable or at least one hash path variable configured?")
 
     def _read_keystone_tenants_map(self, map_path):
         m = {}

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -2,10 +2,11 @@
 """
 OpenStack exporter for the prometheus monitoring system
 
-Copyright (C) 2016 Canonical, Ltd.
+Copyright (C) 2016-2019 Canonical, Ltd.
 Authors:
   Jacek Nykis <jacek.nykis@canonical.com>
   Laurent Sesques <laurent.sesques@canonical.com>
+  Paul Collins <paul.collins@canonical.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3,
@@ -42,6 +43,11 @@ from BaseHTTPServer import HTTPServer
 from SocketServer import ForkingMixIn
 from prometheus_client import CollectorRegistry, generate_latest, Gauge, CONTENT_TYPE_LATEST
 from netaddr import IPRange
+
+import random
+import swift.common.utils
+
+from swift.common.ring import ring
 
 import logging
 import logging.handlers
@@ -614,6 +620,71 @@ class Swift():
         return generate_latest(self.registry)
 
 
+class SwiftAccountUsage():
+    def __init__(self):
+        self.registry = CollectorRegistry()
+
+        self.hash_path_prefix = config.get('hash_path_prefix', None)
+        if self.hash_path_prefix:
+            swift.common.utils.HASH_PATH_PREFIX = self.hash_path_prefix
+        self.hash_path_suffix = config.get('hash_path_suffix', None)
+        if self.hash_path_suffix:
+            swift.common.utils.HASH_PATH_SUFFIX = self.hash_path_suffix
+
+        self.reseller_prefix = config['reseller_prefix']
+        self.ring_path = config['ring_path']
+
+        self.account_ring = self._get_account_ring()
+
+    def _read_keystone_tenants_map(self, map_path):
+        m = {}
+        with open(map_path) as km:
+            line = km.readline()
+            while line != '':
+                name, id = line.strip().split()
+                m[name] = id
+                line = km.readline()
+
+        return m
+
+    def _get_account_ring(self):
+        """Read the account ring from the configured location, and return it."""
+        return ring.Ring(
+            serialized_path=self.ring_path,
+            ring_name='account',
+            )
+
+    def _get_account_usage(self, account):
+        partition, nodes = self.account_ring.get_nodes(account=account)
+        node = random.choice(nodes)
+        account_url = 'http://{ip}:{port}/{device}/{partition}/{account}'.format(
+            account=account,
+            partition=partition,
+            **node)
+        response = requests.head(account_url)
+        if response.status_code == 204:
+            return int(response.headers['X-Account-Bytes-Used'])
+        else:
+            return 0
+
+    def gen_account_stats(self):
+        self.keystone_tenants_map = self._read_keystone_tenants_map(
+            config['keystone_tenants_map'])
+        labels = ['cloud', 'swift_account', 'tenant']
+        swift_account = Gauge(
+            'swift_account_bytes_used', 'Swift account usage in bytes', labels, registry=self.registry)
+
+        for tenant_name, tenant_id in self.keystone_tenants_map.iteritems():
+            account = self.reseller_prefix + tenant_id
+            bytes_used = self._get_account_usage(account)
+
+            swift_account.labels(config['cloud'], account, tenant_name).set(bytes_used)
+
+    def get_stats(self):
+        self.gen_account_stats()
+        return generate_latest(self.registry)
+
+
 class ForkingHTTPServer(ForkingMixIn, HTTPServer):
     pass
 
@@ -630,11 +701,13 @@ class OpenstackExporterHandler(BaseHTTPRequestHandler):
                 nova = Nova()
                 cinder = Cinder()
                 swift = Swift()
+                swift_account_usage = SwiftAccountUsage()
                 log.debug("Collecting stats..")
                 output = neutron.get_stats() + \
                     nova.get_stats() + \
                     cinder.get_stats() + \
                     swift.get_stats() + \
+                    swift_account_usage.get_stats() + \
                     data_gatherer.get_stats()
                 self.send_response(200)
                 self.send_header('Content-Type', CONTENT_TYPE_LATEST)

--- a/prometheus-openstack-exporter.yaml
+++ b/prometheus-openstack-exporter.yaml
@@ -10,6 +10,15 @@ openstack_allocation_ratio_vcpu: 2.5
 openstack_allocation_ratio_ram: 1.1
 openstack_allocation_ratio_disk: 1.0
 
+# Configure the enabled collectors here.  Note that the Swift account
+# collector in particular has special requirements.
+enabled_collectors:
+  - cinder
+  - neutron
+  - nova
+  - swift
+#  - swift-account-usage
+
 # To export hypervisor_schedulable_instances metric set desired instance size
 schedulable_instance_size:
     ram_mbs: 4096

--- a/prometheus-openstack-exporter.yaml
+++ b/prometheus-openstack-exporter.yaml
@@ -1,5 +1,5 @@
 # Example configuration file for prometheus-openstack-exporter
-# Copyright (C) 2016 Canonical, Ltd.
+# Copyright (C) 2016-2019 Canonical, Ltd.
 #
 
 listen_port: 9183
@@ -16,11 +16,38 @@ schedulable_instance_size:
     vcpu: 2
     disk_gbs: 20
 
+# Uncomment if the cloud doesn't provide cinder / nova volumes:
+#use_nova_volumes: False
+
+## Swift
+
 # There is no way to retrieve them using OpenStack APIs
 # For clouds deployed without swift, remove this part
 swift_hosts:
     - host1.example.com
     - host2.example.com
 
-# Uncomment if the cloud doesn't provide cinder / nova volumes:
-#use_nova_volumes: False
+# There is no API to ask Swift for a list of accounts it knows about.
+# Even if there were, Swift (in common case of Keystone auth, at
+# least) only knows them by the corresponding tenant ID, which would
+# be a less than useful label without post-processing.  The following
+# should point to a file containing one line per tenant, with the
+# tenant name first, then whitespace, followed by the tenant ID.
+keystone_tenants_map:
+
+# The reseller prefix is typically used by the Swift middleware to
+# keep accounts with different providers separate.  We would ideally
+# look this up dynamically from the Swift configuration.
+# The Keystone middlware defaults to the following value.
+reseller_prefix: AUTH_
+
+ring_path: /etc/swift
+
+# These will typically be read from /etc/swift/swift.conf.  If that
+# file cannot be opened, then the Swift library will log an error and
+# try to exit.  To run p-s-a-e as a user other than Swift, these
+# settings must be set to the same values as Swift itself, and the
+# above must point to an always-current readable copy of the rings.
+
+hash_path_prefix:
+hash_path_suffix:


### PR DESCRIPTION
This branch adds SwiftAccountUsage and its configuration variables and wires it all up.

It's been running happily in its various iterations on one of our production Swift clusters for about week or so.

I've also added an enabled_collectors directive. It is most straightforward to run SwiftAccountUsage on a swift-proxy node, which is far from the best place to run a whole-cloud exporter. I've left in place the legacy methods for disabling the swift and cinder collectors, but these should probably go away eventually.

I've started writing some tests for this new code, which will be the first tests for this entire project, and will submit them in a followup.