### PR TITLE
Revert "Update marker to get the next instances"

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -175,7 +175,7 @@ class DataGatherer(Thread):
             search_opts = {'all_tenants': '1', 'limit': '100', 'marker': marker}
             new_instances = [x._info for x in nova.servers.list(search_opts=search_opts)]
             if new_instances:
-                search_opts['marker'] = new_instances[-1]['id']
+                marker = new_instances[-1]['id']
                 info['instances'].extend(new_instances)
             else:
                 break


### PR DESCRIPTION
Reverts CanonicalLtd/prometheus-openstack-exporter#65

Per @gabrielegiammatteo, the original code should work and this change is definitely wrong because search_opts is reset every time around the loop with an empty marker.