### PR TITLE
Fixed default set of collectors, it shouldn't include the newer swift-account-usage

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -645,6 +645,9 @@ class SwiftAccountUsage():
                 "Is swift.conf readable or at least one hash path variable configured?")
 
     def _read_keystone_tenants_map(self, map_path):
+        if not map_path:
+            return {}
+
         m = {}
         with open(map_path) as km:
             line = km.readline()
@@ -715,10 +718,10 @@ DATA_GATHERER_USERS = [
 
 def get_collectors(collectors):
     # For backwards compatibility and when enabled_collectors isn't defined,
-    # specify default set of collectors.
+    # specify default set of collectors before commit 662b70f and f27cda8.
     # https://github.com/CanonicalLtd/prometheus-openstack-exporter/issues/80
     if not collectors:
-        return COLLECTORS.keys()
+        return ['cinder', 'swift', 'nova', 'neutron']
     return collectors
 
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: prometheus-openstack-exporter
-version: 0.1.1
+version: 0.1.2
 summary: Exposes high level OpenStack metrics to Prometheus.
 description: |
   Exposes high level OpenStack metrics to Prometheus


### PR DESCRIPTION
https://github.com/CanonicalLtd/prometheus-openstack-exporter/issues/82