### PR TITLE
[Fix regression] Add log level setting to docker image

### DIFF
--- a/admin.novarc.example
+++ b/admin.novarc.example
@@ -9,6 +9,7 @@ OS_INTERFACE=internal
 OS_IDENTITY_API_VERSION=3
 OS_REGION_NAME=mycloud
 
+#logLevel=INFO
 #listenPort=9183
 #cacheRefreshInterval=300
 #vcpuRatio=1.0

--- a/prometheus-openstack-exporter.sample.yaml
+++ b/prometheus-openstack-exporter.sample.yaml
@@ -9,6 +9,7 @@ cloud: VAR_CLOUD # cloud=${OS_REGION_NAME:-mycloud}
 openstack_allocation_ratio_vcpu: VAR_VCPU_RATIO # vcpuRatio=1.0
 openstack_allocation_ratio_ram: VAR_RAM_RATIO # ramRatio=1.0
 openstack_allocation_ratio_disk: VAR_DISK_RATIO # diskRatio=1.0
+log_level: VAR_LOG_LEVEL # logLevel=INFO
 
 # Configure the enabled collectors here.  Note that the Swift account
 # collector in particular has special requirements.

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -2,6 +2,7 @@
 
 prometheusDir='/etc/prometheus'
 configFile=${configFile:-"${prometheusDir}/prometheus-openstack-exporter.yaml"}
+logLevel=${logLevel:-INFO}
 listenPort=${listenPort:-9183}
 cacheRefreshInterval=${cacheRefreshInterval:-300}
 cacheFileName=${cacheFileName:-"$(mktemp -p /dev/shm/)"}
@@ -26,6 +27,7 @@ if [ ! -e "${configFile}" ]; then
     cp prometheus-openstack-exporter.sample.yaml ${configFile}
     
     sed -i "s|VAR_LISTEN_PORT|${listenPort}|g" 					${configFile}
+    sed -i "s|VAR_LOG_LEVEL|${logLevel}|g" 					${configFile}
     sed -i "s|VAR_CACHE_REFRESH_INTERVAL|${cacheRefreshInterval}|g" 		${configFile}
     sed -i "s|VAR_CACHE_FILE|${cacheFileName}|g" 				${configFile}
     sed -i "s|VAR_CLOUD|${cloud}|g" 						${configFile}


### PR DESCRIPTION
PR #48 Introduced regression for docker containers. 
If you try to build docker image from the master branch and run container it will constantly fail with error because it can't find log_level setting in config file used in docker (prometheus-openstack-exporter.sample.yaml): 

Traceback (most recent call last):
  File "/prometheus-openstack-exporter", line 791, in <module>
    numeric_log_level = getattr(logging, config.get('log_level').upper(), None)
AttributeError: 'NoneType' object has no attribute 'upper'

