### PR TITLE
Add LOG_LEVEL variable to configuration files

### DIFF
--- a/admin.novarc.example
+++ b/admin.novarc.example
@@ -10,6 +10,7 @@ OS_IDENTITY_API_VERSION=3
 OS_REGION_NAME=mycloud
 
 #listenPort=9183
+#logLevel=INFO
 #cacheRefreshInterval=300
 #vcpuRatio=1.0
 #ramRatio=1.0

--- a/prometheus-openstack-exporter.sample.yaml
+++ b/prometheus-openstack-exporter.sample.yaml
@@ -3,6 +3,7 @@
 #
 
 listen_port: VAR_LISTEN_PORT # listenPort=9183
+log_level: VAR_LOG_LEVEL # logLevel=INFO
 cache_refresh_interval: VAR_CACHE_REFRESH_INTERVAL # cacheRefreshInterval=300 In seconds
 cache_file: VAR_CACHE_FILE # cacheFileName=$(mktemp -p /dev/shm/)
 cloud: VAR_CLOUD # cloud=${OS_REGION_NAME:-mycloud}

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -3,6 +3,7 @@
 prometheusDir='/etc/prometheus'
 configFile=${configFile:-"${prometheusDir}/prometheus-openstack-exporter.yaml"}
 listenPort=${listenPort:-9183}
+logLevel=${logLevel:-INFO}
 cacheRefreshInterval=${cacheRefreshInterval:-300}
 cacheFileName=${cacheFileName:-"$(mktemp -p /dev/shm/)"}
 cloud=${OS_REGION_NAME:-mycloud}
@@ -26,6 +27,7 @@ if [ ! -e "${configFile}" ]; then
     cp prometheus-openstack-exporter.sample.yaml ${configFile}
     
     sed -i "s|VAR_LISTEN_PORT|${listenPort}|g" 					${configFile}
+    sed -i "s|VAR_LOG_LEVEL|${logLevel}|g"		 			${configFile}
     sed -i "s|VAR_CACHE_REFRESH_INTERVAL|${cacheRefreshInterval}|g" 		${configFile}
     sed -i "s|VAR_CACHE_FILE|${cacheFileName}|g" 				${configFile}
     sed -i "s|VAR_CLOUD|${cloud}|g" 						${configFile}


### PR DESCRIPTION
After merging #48, building docker image via default Dockerfile is broken as configuration files don't have proper variables. This PR fixes it.