### PR TITLE
Add python-novaclient to requirements which is needed for tests to pass

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ flake8
 mock
 prometheus-client
 python-neutronclient
+python-novaclient
 swift


### PR DESCRIPTION
python-novaclient is needed for tests to pass - add to requirements.txt