### PR TITLE
Fixed requirements for lint and lint failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+configparser==3.5
 flake8
 mock
 prometheus-client

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "python-neutronclient<=6.1.0",
         "python-cinderclient",
         "netaddr",
-        "swift"
+        "swift",
     ],
     long_description=read('README.md'),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -15,19 +15,20 @@ setup(
     keywords=["prometheus", "openstack", "exporter"],
     url="https://github.com/CanonicalLtd/prometheus-openstack-exporter",
     scripts=["prometheus-openstack-exporter"],
-    install_requires=["prometheus_client",
-                      "python-keystoneclient<=3.10.0",
-                      "python-novaclient==6.0.0",
-                      "python-neutronclient<=6.1.0",
-                      "python-cinderclient",
-                      "netaddr",
-                      "swift"
+    install_requires=[
+        "prometheus_client",
+        "python-keystoneclient<=3.10.0",
+        "python-novaclient==6.0.0",
+        "python-neutronclient<=6.1.0",
+        "python-cinderclient",
+        "netaddr",
+        "swift"
     ],
     long_description=read('README.md'),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: System :: Networking :: Monitoring",
         "License :: OSI Approved :: "
-            "GNU General Public License v3 or later (GPLv3+)",
+        "GNU General Public License v3 or later (GPLv3+)",
     ],
 )


### PR DESCRIPTION
'make lint' fails with configparser 4:

Installing collected packages: pyflakes, mccabe, configparser, pycodestyle, functools32, entrypoints, typing, enum34, flake8, funcsigs, six, mock, prometheus-client, pbr, pytz, Babel, oslo.i18n, PyYAML, iso8601, wrapt, debtcollector, pyparsing, monotonic, netaddr, netifaces, oslo.utils, msgpack, oslo.serialization, idna, chardet, certifi, urllib3, requests, stevedore, os-service-types, keystoneauth1, jsonpointer, jsonpatch, appdirs, requestsexceptions, jmespath, ipaddress, munch, futures, decorator, dogpile.cache, pycparser, cffi, cryptography, openstacksdk, os-client-config, simplejson, rfc3986, oslo.config, python-keystoneclient, PrettyTable, unicodecsv, contextlib2, wcwidth, pyperclip, subprocess32, cmd2, cliff, osc-lib, pyinotify, python-dateutil, oslo.context, oslo.log, python-neutronclient, python-novaclient, xattr, PasteDeploy, dnspython, lxml, PyECLib, greenlet, eventlet, swift
Successfully installed Babel-2.7.0 PasteDeploy-2.0.1 PrettyTable-0.7.2 PyECLib-1.6.0 PyYAML-5.1.2 appdirs-1.4.3 certifi-2019.9.11 cffi-1.13.1 chardet-3.0.4 cliff-2.16.0 cmd2-0.8.9 configparser-4.0.2 contextlib2-0.6.0.post1 cryptography-2.8 debtcollector-1.22.0 decorator-4.4.1 dnspython-1.16.0 dogpile.cache-0.9.0 entrypoints-0.3 enum34-1.1.6 eventlet-0.25.1 flake8-3.7.9 funcsigs-1.0.2 functools32-3.2.3.post2 futures-3.3.0 greenlet-0.4.15 idna-2.8 ipaddress-1.0.23 iso8601-0.1.12 jmespath-0.9.4 jsonpatch-1.24 jsonpointer-2.0 keystoneauth1-3.18.0 lxml-4.4.1 mccabe-0.6.1 mock-3.0.5 monotonic-1.5 msgpack-0.6.2 munch-2.3.2 netaddr-0.7.19 netifaces-0.10.9 openstacksdk-0.37.0 os-client-config-1.33.0 os-service-types-1.7.0 osc-lib-1.14.1 oslo.config-6.11.1 oslo.context-2.23.0 oslo.i18n-3.24.0 oslo.log-3.44.1 oslo.serialization-2.29.2 oslo.utils-3.41.2 pbr-5.4.3 prometheus-client-0.7.1 pycodestyle-2.5.0 pycparser-2.19 pyflakes-2.1.1 pyinotify-0.9.6 pyparsing-2.4.2 pyperclip-1.7.0 python-dateutil-2.8.0 python-keystoneclient-3.22.0 python-neutronclient-6.14.0 python-novaclient-16.0.0 pytz-2019.3 requests-2.22.0 requestsexceptions-1.4.0 rfc3986-1.3.2 simplejson-3.16.0 six-1.12.0 stevedore-1.31.0 subprocess32-3.5.4 swift-2.23.1 typing-3.7.4.1 unicodecsv-0.14.1 urllib3-1.25.6 wcwidth-0.1.7 wrapt-1.11.2 xattr-0.9.6
/tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter//.venv/bin/python2.7 -m flake8 /tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter/ /tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter//prometheus-openstack-exporter
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter/.venv/lib/python2.7/site-packages/flake8/__main__.py", line 2, in <module>
    from flake8.main import cli
  File "/tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter/.venv/local/lib/python2.7/site-packages/flake8/main/cli.py", line 4, in <module>
    from flake8.main import application
  File "/tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter/.venv/local/lib/python2.7/site-packages/flake8/main/application.py", line 16, in <module>
    from flake8.main import options
  File "/tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter/.venv/local/lib/python2.7/site-packages/flake8/main/options.py", line 4, in <module>
    from flake8.main import vcs
  File "/tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter/.venv/local/lib/python2.7/site-packages/flake8/main/vcs.py", line 4, in <module>
    from flake8.main import mercurial
  File "/tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter/.venv/local/lib/python2.7/site-packages/flake8/main/mercurial.py", line 7, in <module>
    import configparser
  File "/tmp/tmpfiles-hloeung/tmp/prometheus-openstack-exporter/.venv/local/lib/python2.7/site-packages/configparser.py", line 11, in <module>
    from backports.configparser import (
ImportError: cannot import name ConverterMapping
make: *** [Makefile:36: lint-python] Error 1