### PR TITLE
Fixed NoneType has no attribute 'upper'

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -792,10 +792,10 @@ if __name__ == '__main__':
     else:
         log.addHandler(logging.StreamHandler())
     config = yaml.safe_load(args.config_file.read())
-    numeric_log_level = getattr(logging, config.get('log_level').upper(), None)
+    numeric_log_level = getattr(logging, config.get('log_level', 'INFO').upper(), None)
     if not isinstance(numeric_log_level, int):
         raise ValueError('Invalid log level: %s' % config.get('log_level'))
-    log.setLevel(numeric_log_level) 
+    log.setLevel(numeric_log_level)
     data_gatherer = None
     if data_gatherer_needed(config):
         data_gatherer = DataGatherer()


### PR DESCRIPTION
> Nov 14 07:52:57 sliggoo prometheus-openstack-exporter.prometheus-openstack-exporter[1897833]: Traceback (most recent call last):
> Nov 14 07:52:57 sliggoo prometheus-openstack-exporter.prometheus-openstack-exporter[1897833]:   File "/snap/prometheus-openstack-exporter/30/bin/prometheus-openstack-exporter", line 795, in <module>
> Nov 14 07:52:57 sliggoo prometheus-openstack-exporter.prometheus-openstack-exporter[1897833]:     numeric_log_level = getattr(logging, config.get('log_level').upper(), None)
> Nov 14 07:52:57 sliggoo prometheus-openstack-exporter.prometheus-openstack-exporter[1897833]: AttributeError: 'NoneType' object has no attribute 'upper'

This was introduced in commit 7a86dee2