### PR TITLE
Add missing snap build dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,11 @@ parts:
       - libxslt1-dev
       # for building cffi
       - libffi-dev
+      # for building cryptography
+      - rustc
+      - cargo
+      - libssl-dev
+      - pkg-config
     stage-packages:
       - libdb5.3
       - liberasurecode-dev


### PR DESCRIPTION
On some architectures, binary wheels for some pypi packages aren't available, so pip must build them from source.  Some of these require more build dependencies that must be installed:

- `lxml` requires `libxml2-dev` and `libxslt1-dev`
- `cffi` requires `libffi-dev`
- `cryptography` requires `rustc`, `cargo`, `libssl-dev`, `pkg-config`