### PR TITLE
Use CPU info instead of hypervisor list data

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -611,7 +611,14 @@ class Nova:
                 ]
                 # Disabled hypervisors return None below, convert to 0
                 vms.labels(*label_values).set(squashnone(h["running_vms"]))
-                vcpus_total.labels(*label_values).set(squashnone(h["vcpus"]))
+                if h.get("cpu_info"):
+                    vcpus_total.labels(*label_values).set(
+                        squashnone(eval(h["cpu_info"])["topology"]["cores"])
+                        * squashnone(eval(h["cpu_info"])["topology"]["threads"])
+                        * squashnone(eval(h["cpu_info"])["topology"]["sockets"])
+                    )
+                else:
+                    vcpus_total.labels(*label_values).set(squashnone(h["vcpus"]))
                 vcpus_used.labels(*label_values).set(squashnone(h["vcpus_used"]))
                 mem_total.labels(*label_values).set(squashnone(h["memory_mb"]))
                 mem_used.labels(*label_values).set(squashnone(h["memory_mb_used"]))
@@ -637,7 +644,14 @@ class Nova:
                 ]
                 # Disabled hypervisors return None below, convert to 0
                 vms.labels(*label_values).set(squashnone(h["running_vms"]))
-                vcpus_total.labels(*label_values).set(squashnone(h["vcpus"]))
+                if h.get("cpu_info"):
+                    vcpus_total.labels(*label_values).set(
+                        squashnone(eval(h["cpu_info"])["topology"]["cores"])
+                        * squashnone(eval(h["cpu_info"])["topology"]["threads"])
+                        * squashnone(eval(h["cpu_info"])["topology"]["sockets"])
+                    )
+                else:
+                    vcpus_total.labels(*label_values).set(squashnone(h["vcpus"]))
                 vcpus_used.labels(*label_values).set(squashnone(h["vcpus_used"]))
                 mem_total.labels(*label_values).set(squashnone(h["memory_mb"]))
                 mem_used.labels(*label_values).set(squashnone(h["memory_mb_used"]))


### PR DESCRIPTION
The total amount of VCPUs should be obtained from
cpu_info instead of VCPUs column of hypervisor list, which does not account for pinned CPUs specified by cpu_dedicated_set nova config option.

The cpu_info data may be empty in some circumstances (such as old openstack client or certain virt drivers), so fallback to old method in that case.

Reserved CPUs are accounted in the "VCPUs Used" column of hypervisor list output.

Closes: #152